### PR TITLE
Rename Lifecycle Methond to UNSAFE

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,8 +109,8 @@ export default class Carousel extends React.Component {
   }
 
   // @TODO Remove deprecated componentWillReceiveProps with getDerivedStateFromProps
-  // eslint-disable-next-line react/no-deprecated
-  componentWillReceiveProps(nextProps) {
+  // eslint-disable-next-line react/no-deprecated, camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const slideCount = getValidChildren(nextProps.children).length;
     const slideCountChanged = slideCount !== this.state.slideCount;
     this.setState(prevState => ({


### PR DESCRIPTION
### Description

We are updating Segway to React version 16.9.0.  In this version, componentWillReceiveProps has been marked for deprecation and will be removed in v17.  ( This currently just a forked version of Nuka and we will likely revert back to the original once they release the upcoming changes ) Carousel still uses this method so to fix this temporarily we are adding the required UNSAFE_ prefix to suppress the warnings.  

#### Type of Change

Renamed componentWillReceiveProps to UNSAFE_componentWillReceiveProps

